### PR TITLE
修复 WebViewProxy 数据目录隔离未生效问题

### DIFF
--- a/Bcore/src/main/java/top/niunaijun/blackbox/app/BActivityThread.java
+++ b/Bcore/src/main/java/top/niunaijun/blackbox/app/BActivityThread.java
@@ -30,7 +30,6 @@ import android.os.RemoteException;
 import android.os.StrictMode;
 import android.text.TextUtils;
 import android.util.Log;
-import android.webkit.WebView;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -76,6 +75,7 @@ import top.niunaijun.blackbox.fake.delegate.ContentProviderDelegate;
 
 import top.niunaijun.blackbox.fake.hook.HookManager;
 import top.niunaijun.blackbox.fake.service.HCallbackProxy;
+import top.niunaijun.blackbox.fake.service.WebViewProxy;
 import top.niunaijun.blackbox.utils.Reflector;
 import top.niunaijun.blackbox.utils.SafeContextWrapper;
 import top.niunaijun.blackbox.utils.GlobalContextWrapper;
@@ -388,9 +388,7 @@ public class BActivityThread extends IBActivityThread.Stub {
                 StrictModeCompat.disableDeathOnFileUriExposure();
             }
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            WebView.setDataDirectorySuffix(getUserId() + ":" + packageName + ":" + processName);
-        }
+        WebViewProxy.ensureDataDirectorySuffix(packageName, processName);
 
         VirtualRuntime.setupRuntime(processName, applicationInfo);
 

--- a/Bcore/src/main/java/top/niunaijun/blackbox/fake/service/WebViewProxy.java
+++ b/Bcore/src/main/java/top/niunaijun/blackbox/fake/service/WebViewProxy.java
@@ -1,39 +1,28 @@
 package top.niunaijun.blackbox.fake.service;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
 import android.os.Build;
 import android.webkit.WebView;
-import android.webkit.WebViewDatabase;
-import android.webkit.WebSettings;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import top.niunaijun.blackbox.BlackBoxCore;
-import top.niunaijun.blackbox.fake.hook.ClassInvocationStub;
-import top.niunaijun.blackbox.fake.hook.MethodHook;
-import top.niunaijun.blackbox.fake.hook.ProxyMethod;
+import top.niunaijun.blackbox.fake.hook.IInjectHook;
 import top.niunaijun.blackbox.utils.Slog;
 import top.niunaijun.blackbox.app.BActivityThread;
 
 
-public class WebViewProxy extends ClassInvocationStub {
+public class WebViewProxy implements IInjectHook {
     public static final String TAG = "WebViewProxy";
+    private static final Object WEBVIEW_DATA_DIR_LOCK = new Object();
+    private static String sInstalledDataDirectorySuffix;
 
     public WebViewProxy() {
-        super();
-    }
-
-    
-    @Override
-    protected Object getWho() {
-        return null; 
     }
 
     @Override
-    protected void inject(Object baseInvocation, Object proxyInvocation) {
-        
+    public void injectHook() {
+        ensureDataDirectorySuffix(BActivityThread.getAppPackageName(), BActivityThread.getAppProcessName());
     }
 
     @Override
@@ -41,257 +30,86 @@ public class WebViewProxy extends ClassInvocationStub {
         return false;
     }
 
-    
-    @ProxyMethod("<init>")
-    public static class Constructor extends MethodHook {
-        @Override
-        protected Object hook(Object who, Method method, Object[] args) throws Throwable {
-            Slog.d(TAG, "WebView: Constructor called, intercepting to prevent data directory conflicts");
-            Context context = null;
-            try {
-                if (args != null && args.length > 0 && args[0] instanceof Context) {
-                    context = (Context) args[0];
-                } else {
-                    context = BlackBoxCore.getContext();
+    public static void ensureDataDirectorySuffix(String packageName, String processName) {
+        String suffix = buildDataDirectorySuffix(packageName, processName);
+        if (suffix == null) {
+            Slog.d(TAG, "WebView: skip data directory suffix because app package is not ready");
+            return;
+        }
+
+        synchronized (WEBVIEW_DATA_DIR_LOCK) {
+            if (suffix.equals(sInstalledDataDirectorySuffix)) {
+                return;
+            }
+
+            File dataDir = ensureHostWebViewDir(suffix);
+            if (dataDir != null) {
+                System.setProperty("webview.data.dir", dataDir.getAbsolutePath());
+                System.setProperty("webview.cache.dir", new File(dataDir, "cache").getAbsolutePath());
+                System.setProperty("webview.cookies.dir", new File(dataDir, "cookies").getAbsolutePath());
+            }
+
+            boolean installed = true;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                try {
+                    WebView.setDataDirectorySuffix(suffix);
+                    Slog.d(TAG, "WebView: installed data directory suffix: " + suffix);
+                } catch (IllegalStateException e) {
+                    Slog.w(TAG, "WebView: data directory suffix was already locked by WebView", e);
+                } catch (Throwable e) {
+                    Slog.w(TAG, "WebView: failed to install data directory suffix", e);
+                    installed = false;
                 }
-
-                if (context != null) {
-                    
-                    String packageName = context.getPackageName();
-                    String userId = String.valueOf(BActivityThread.getUserId());
-                    String uniqueDataDir = context.getApplicationInfo().dataDir + "/webview_" + userId + "_" + android.os.Process.myPid();
-
-                    
-                    File dataDir = new File(uniqueDataDir);
-                    if (!dataDir.exists()) {
-                        dataDir.mkdirs();
-                        Slog.d(TAG, "WebView: Created unique data directory: " + uniqueDataDir);
-                    }
-
-                    
-                    System.setProperty("webview.data.dir", uniqueDataDir);
-                    System.setProperty("webview.cache.dir", uniqueDataDir + "/cache");
-                    System.setProperty("webview.cookies.dir", uniqueDataDir + "/cookies");
-
-                    Slog.d(TAG, "WebView: Set custom data directory: " + uniqueDataDir);
-                }
-
-                
-                Object result = method.invoke(who, args);
-
-                if (result instanceof WebView) {
-                    WebView webView = (WebView) result;
-                    
-                    configureWebView(webView);
-                }
-
-                return result;
-            } catch (Exception e) {
-                Slog.w(TAG, "WebView: Constructor failed, attempting fallback", e);
-                
-                return createFallbackWebView(context);
+            }
+            if (installed) {
+                sInstalledDataDirectorySuffix = suffix;
             }
         }
-        
-        private void configureWebView(WebView webView) {
-            try {
-                WebSettings settings = webView.getSettings();
-                if (settings != null) {
-                    
-                    settings.setJavaScriptEnabled(true);
-                    
-                    settings.setDomStorageEnabled(true);
-                    
-                    settings.setDatabaseEnabled(true);
-                    
-                    settings.setCacheMode(WebSettings.LOAD_DEFAULT);
+    }
 
-                    
-                    try {
-                        
-                        Method setAppCacheEnabled = settings.getClass().getMethod("setAppCacheEnabled", boolean.class);
-                        setAppCacheEnabled.invoke(settings, true);
-
-                        if (webView.getContext() != null) {
-                            Method setAppCachePath = settings.getClass().getMethod("setAppCachePath", String.class);
-                            setAppCachePath.invoke(settings, webView.getContext().getCacheDir().getAbsolutePath());
-                        }
-                    } catch (Throwable e) {
-                        
-                        Slog.w(TAG, "WebView: AppCache not supported: " + e.getMessage());
-                    }
-
-                    
-                    settings.setBlockNetworkLoads(false);
-                    settings.setBlockNetworkImage(false);
-
-                    
-                    settings.setAllowFileAccess(true);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                        settings.setAllowFileAccessFromFileURLs(true);
-                        settings.setAllowUniversalAccessFromFileURLs(true);
-                    }
-
-                    
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
-                    }
-
-                    
-                    String userAgent = settings.getUserAgentString();
-                    if (userAgent != null && !userAgent.contains("BlackBox")) {
-                        settings.setUserAgentString(userAgent + " BlackBox");
-                    }
-
-                    
-                    try {
-                        webView.setNetworkAvailable(true);
-                    } catch (Exception e) {
-                        
-                    }
-
-                    
-                    settings.setAllowContentAccess(true);
-
-                    
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                         settings.setSafeBrowsingEnabled(false);
-                    }
-
-                    Slog.d(TAG, "WebView: Configured successfully with network access enabled");
-                }
-            } catch (Exception e) {
-                Slog.w(TAG, "WebView: Failed to configure settings", e);
-            }
-        }
-        
-        private WebView createFallbackWebView(Context context) {
-            try {
-                if (context != null) {
-                    
-                    WebView webView = new WebView(context);
-                    WebSettings settings = webView.getSettings();
-                    if (settings != null) {
-                        settings.setJavaScriptEnabled(true);
-                        settings.setDomStorageEnabled(true);
-                    }
-                    Slog.d(TAG, "WebView: Created fallback WebView");
-                    return webView;
-                }
-            } catch (Exception e) {
-                Slog.e(TAG, "WebView: Failed to create fallback WebView", e);
-            }
+    private static String buildDataDirectorySuffix(String packageName, String processName) {
+        if (packageName == null || packageName.length() == 0) {
             return null;
         }
+        String currentProcess = processName;
+        if (currentProcess == null || currentProcess.length() == 0) {
+            currentProcess = packageName;
+        }
+        return sanitizeSuffix(BActivityThread.getUserId() + "_" + packageName + "_" + currentProcess);
     }
 
-    
-    @ProxyMethod("setDataDirectorySuffix")
-    public static class SetDataDirectorySuffix extends MethodHook {
-        @Override
-        protected Object hook(Object who, Method method, Object[] args) throws Throwable {
-            try {
-                if (args != null && args.length > 0) {
-                    String suffix = (String) args[0];
-                    Slog.d(TAG, "WebView: setDataDirectorySuffix called with: " + suffix);
-                    
-                    
-                    Context context = BlackBoxCore.getContext();
-                    String packageName = context != null ? context.getPackageName() : "unknown";
-                    String userId = String.valueOf(BActivityThread.getUserId());
-                    String uniqueSuffix = suffix + "_" + userId + "_" + android.os.Process.myPid();
-                    args[0] = uniqueSuffix;
-                    Slog.d(TAG, "WebView: Using unique suffix: " + uniqueSuffix);
-                }
-                
-                return method.invoke(who, args);
-            } catch (Exception e) {
-                Slog.w(TAG, "WebView: setDataDirectorySuffix failed, continuing without suffix", e);
-                return null; 
+    private static String sanitizeSuffix(String suffix) {
+        StringBuilder builder = new StringBuilder(suffix.length());
+        for (int i = 0; i < suffix.length(); i++) {
+            char c = suffix.charAt(i);
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-') {
+                builder.append(c);
+            } else {
+                builder.append('_');
             }
         }
+        return builder.toString();
     }
 
-    
-    @ProxyMethod("getDataDirectory")
-    public static class GetDataDirectory extends MethodHook {
-        @Override
-        protected Object hook(Object who, Method method, Object[] args) throws Throwable {
-            try {
-                Slog.d(TAG, "WebView: getDataDirectory called, returning unique directory");
-                
-                
-                Context context = BlackBoxCore.getContext();
-                if (context != null) {
-                    String packageName = context.getPackageName();
-                    String userId = String.valueOf(BActivityThread.getUserId());
-                    String uniqueDir = context.getApplicationInfo().dataDir + "/webview_" + userId + "_" + android.os.Process.myPid();
-                    
-                    
-                    File dir = new File(uniqueDir);
-                    if (!dir.exists()) {
-                        dir.mkdirs();
-                    }
-                    
-                    Slog.d(TAG, "WebView: Returning unique data directory: " + uniqueDir);
-                    return uniqueDir;
-                }
-                
-                return method.invoke(who, args);
-            } catch (Exception e) {
-                Slog.w(TAG, "WebView: getDataDirectory failed, returning fallback", e);
-                
-                return "/data/data/" + BlackBoxCore.getHostPkg() + "/webview_fallback";
-            }
-        }
-    }
-
-    
-    @ProxyMethod("getInstance")
-    public static class GetWebViewDatabaseInstance extends MethodHook {
-        @Override
-        protected Object hook(Object who, Method method, Object[] args) throws Throwable {
-            Slog.d(TAG, "WebView: getInstance called for WebViewDatabase");
-            
-            try {
-                
-                Context context = BlackBoxCore.getContext();
-                if (context != null) {
-                    
-                    String packageName = context.getPackageName();
-                    String userId = String.valueOf(BActivityThread.getUserId());
-                    String uniqueDbPath = context.getApplicationInfo().dataDir + "/webview_db_" + userId + "_" + android.os.Process.myPid();
-                    
-                    
-                    System.setProperty("webview.database.path", uniqueDbPath);
-                    Slog.d(TAG, "WebView: Set unique database path: " + uniqueDbPath);
-                }
-                
-                return method.invoke(who, args);
-            } catch (Exception e) {
-                Slog.w(TAG, "WebView: Failed to get WebViewDatabase instance", e);
+    private static File ensureHostWebViewDir(String suffix) {
+        try {
+            Context context = BlackBoxCore.getContext();
+            if (context == null || context.getApplicationInfo() == null) {
                 return null;
             }
-        }
-    }
-
-    
-    @ProxyMethod("loadUrl")
-    public static class LoadUrl extends MethodHook {
-        @Override
-        protected Object hook(Object who, Method method, Object[] args) throws Throwable {
-            if (args != null && args.length > 0) {
-                String url = (String) args[0];
-                Slog.d(TAG, "WebView: loadUrl called with: " + url);
-                
-                
-                if (url != null && url.startsWith("file://")) {
-                    
-                    Slog.d(TAG, "WebView: Handling file URL: " + url);
-                }
+            File dataDir = new File(new File(context.getApplicationInfo().dataDir, "webview"), suffix);
+            File cacheDir = new File(dataDir, "cache");
+            File cookiesDir = new File(dataDir, "cookies");
+            if (!cacheDir.exists()) {
+                cacheDir.mkdirs();
             }
-            
-            return method.invoke(who, args);
+            if (!cookiesDir.exists()) {
+                cookiesDir.mkdirs();
+            }
+            return dataDir;
+        } catch (Throwable e) {
+            Slog.w(TAG, "WebView: failed to prepare host data directory", e);
+            return null;
         }
     }
 }


### PR DESCRIPTION
## 关联 issue

修复 #35。

## 变更内容

- 将 WebViewProxy 从依赖 ClassInvocationStub 的空代理改为直接实现 IInjectHook，避免 getWho 返回 null 导致初始化直接失效。
- 在 WebViewProxy 注入和 BActivityThread 绑定应用时统一安装 WebView 数据目录 suffix。
- 使用 userId、包名和进程名生成隔离 suffix，并同步准备 WebView data/cache/cookies 目录，降低多虚拟应用/多进程 WebView 数据目录冲突风险。
- 移除原先无法通过 Java 动态代理真正拦截的 WebView 构造函数和静态方法伪 hook。

## 验证

- git diff --check
- 已尝试运行 GRADLE_USER_HOME=/tmp/newblackbox-gradle ./gradlew :Bcore:compileDebugJavaWithJavac，但当前本机只有 JDK 17，项目配置要求 Java 21，因此在 error: invalid source release: 21 处中止。